### PR TITLE
fix: Convert Hugo figure shortcodes to HTML for Eleventy compatibility

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -65,6 +65,18 @@ export default function(eleventyConfig) {
     return array.slice(0, limit);
   });
 
+  // Shortcodes
+  eleventyConfig.addShortcode('figure', function(src, alt = '', width = '', caption = '') {
+    const widthAttr = width ? ` width="${width}"` : '';
+    const altAttr = alt ? ` alt="${alt}"` : '';
+    let html = `<figure><img src="${src}"${widthAttr}${altAttr}>`;
+    if (caption) {
+      html += `<figcaption>${caption}</figcaption>`;
+    }
+    html += '</figure>';
+    return html;
+  });
+
   // Collections
   eleventyConfig.addCollection('posts', (collection) => {
     return collection.getFilteredByTag('writing')

--- a/src/gallery/2016-12-03/index.md
+++ b/src/gallery/2016-12-03/index.md
@@ -14,18 +14,18 @@ tags:
   - natures
 ---
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_051149_16-9.webp" alt="matahari terbit di Wisata Paralayang Malang2">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_051149_16-9.webp" alt="matahari terbit di Wisata Paralayang Malang2"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_051532_16-9.webp" alt="matahari terbit di Wisata Paralayang Malang2">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_051532_16-9.webp" alt="matahari terbit di Wisata Paralayang Malang2"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_051659.webp" alt="matahari terbit di Wisata Paralayang Malang3">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_051659.webp" alt="matahari terbit di Wisata Paralayang Malang3"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_052227_2-1.webp" alt="matahari terbit di Wisata Paralayang Malang4">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_052227_2-1.webp" alt="matahari terbit di Wisata Paralayang Malang4"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_052518.webp" alt="matahari terbit di Wisata Paralayang Malang5">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_052518.webp" alt="matahari terbit di Wisata Paralayang Malang5"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_052553.webp" alt="matahari terbit di Wisata Paralayang Malang6">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_052553.webp" alt="matahari terbit di Wisata Paralayang Malang6"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_052707_16-9.webp" alt="matahari terbit di Wisata Paralayang Malang7">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_052707_16-9.webp" alt="matahari terbit di Wisata Paralayang Malang7"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_053016.webp" alt="matahari terbit di Wisata Paralayang Malang8">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2016-12-03/IMG_20161203_053016.webp" alt="matahari terbit di Wisata Paralayang Malang8"></figure>

--- a/src/gallery/2017-01-26/index.md
+++ b/src/gallery/2017-01-26/index.md
@@ -15,14 +15,14 @@ tags:
   - countryside
 ---
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170125_055007_HDR.webp" alt="matahari terbit dari Villa Setiabudi">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170125_055007_HDR.webp" alt="matahari terbit dari Villa Setiabudi"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170125_053323_HDR.webp" alt="matahari terbit dari Villa Setiabudi">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170125_053323_HDR.webp" alt="matahari terbit dari Villa Setiabudi"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_072011_HDR.webp" alt="pemandangan gunung dan persawahan">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_072011_HDR.webp" alt="pemandangan gunung dan persawahan"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_073103_HDR.webp" alt="pemandangan gunung">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_073103_HDR.webp" alt="pemandangan gunung"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_073105_HDR.webp" alt="pemandangan gunung">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_073105_HDR.webp" alt="pemandangan gunung"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_073124_HDR.webp" alt="pemandangan gunung dan seorang laki-laki yang menatap hampa">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_073124_HDR.webp" alt="pemandangan gunung dan seorang laki-laki yang menatap hampa"></figure>

--- a/src/gallery/2019-04-16/index.md
+++ b/src/gallery/2019-04-16/index.md
@@ -15,10 +15,10 @@ tags:
   - countryside
 ---
 
-{{< figure src="20230730_161023.webp" width="60%" alt="kocheng 1">}}
+<figure><img src="20230730_161023.webp" width="60%" alt="kocheng 1"></figure>
 
-{{< figure src="IMG_20210821_201340.webp" width="60%" alt="kocheng 2">}}
+<figure><img src="IMG_20210821_201340.webp" width="60%" alt="kocheng 2"></figure>
 
-{{< figure src="VID_20190416_120623-0.webp" width="60%" alt="kocheng 3">}}
+<figure><img src="VID_20190416_120623-0.webp" width="60%" alt="kocheng 3"></figure>
 
-{{< figure src="VID-20200808-WA0000-0.webp" alt="kocheng 4">}}
+<figure><img src="VID-20200808-WA0000-0.webp" alt="kocheng 4"></figure>

--- a/src/gallery/2019-04-18/index.md
+++ b/src/gallery/2019-04-18/index.md
@@ -14,4 +14,4 @@ tags:
   - university-institute
 ---
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2019-04-18/IMG_20190418_155010.webp" alt="foto gerbang depan ITB">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2019-04-18/IMG_20190418_155010.webp" alt="foto gerbang depan ITB"></figure>

--- a/src/gallery/2019-04-20/index.md
+++ b/src/gallery/2019-04-20/index.md
@@ -14,6 +14,6 @@ tags:
   - mosque
 ---
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2019-04-20/IMG_20190420_173415.webp" alt="foto masjid Al Irsyad Satya, Kota Baru Parahyangan">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2019-04-20/IMG_20190420_173415.webp" alt="foto masjid Al Irsyad Satya, Kota Baru Parahyangan"></figure>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2019-04-20/IMG_20190420_193827.webp" alt="foto masjid Al Irsyad Satya, Kota Baru Parahyangan">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2019-04-20/IMG_20190420_193827.webp" alt="foto masjid Al Irsyad Satya, Kota Baru Parahyangan"></figure>

--- a/src/gallery/2021-03-20/index.md
+++ b/src/gallery/2021-03-20/index.md
@@ -14,4 +14,4 @@ tags:
   - metropolitan-building
 ---
 
-{{< figure src="/img/IMG_20210320_181851.webp" alt="foto sunset dari JPO Pancoran Barat, Jakarta Selatan" caption="red sunset in Jakarta" >}}
+<figure><img src="/img/IMG_20210320_181851.webp" alt="foto sunset dari JPO Pancoran Barat, Jakarta Selatan"><figcaption>red sunset in Jakarta</figcaption></figure>

--- a/src/writing/2019/city-of-angels-a-rhyme/index.md
+++ b/src/writing/2019/city-of-angels-a-rhyme/index.md
@@ -13,7 +13,7 @@ tags:
 ---
 
 <br/>
-{{< figure src="IMG_20190418_155010_16-9.webp" width="75%" alt="pemandangan gerbang kampus ITB dan seorang wanita yang seperti menatap kosong ke depan">}}
+<figure><img src="IMG_20190418_155010_16-9.webp" width="75%" alt="pemandangan gerbang kampus ITB dan seorang wanita yang seperti menatap kosong ke depan"></figure>
 
 There was a girl with a sky full of stars in her eyes<br/>
 She was chasing a world that was so fast it left her behind<br/>
@@ -28,7 +28,7 @@ Sing back the melody, a song for the hearts left in the streets<br/>
 A voice for the out of reach<br/>
 The city of angels<br/>
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_073124_HDR.webp" width="75%" alt="pemandangan gunung dan seorang laki-laki yang menatap hampa" >}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2017-01-26/IMG_20170126_073124_HDR.webp" width="75%" alt="pemandangan gunung dan seorang laki-laki yang menatap hampa"></figure>
 
 There was a boy with the world in the palm of his hand<br/>
 Bright like a star but he burned everything that he had<br/>

--- a/src/writing/2023/first-experience-of-online-thesis-defense/index.md
+++ b/src/writing/2023/first-experience-of-online-thesis-defense/index.md
@@ -24,7 +24,7 @@ Namun, Allah berkehendak lain. Malam hari setelah ujian terakhir, sebuah kabar y
 
 Dunia seakan menjadi seperti apa yang terjadi di dalam film _apocalypse_. Dari mulai info persebaran penyakit yang sangat cepat, hingga barang ajaib yang tiba-tiba menjadi langka dan mahal.
 
-{{< figure src="857420727_345321.webp" class="left" alt="foto hand sanitizer" width="50%" caption="si benda ajaib saat pandemi" >}}
+<figure><img src="857420727_345321.webp" width="50%" alt="foto hand sanitizer"><figcaption>si benda ajaib saat pandemi</figcaption></figure>
 
 Sudah barangnya langka, sekalinya ketemu langsung dihajar dengan harga Rp 65.000 juga. _Wew_.
 
@@ -34,7 +34,7 @@ Pucuk dicinta, ulam pun tiba. Kampus pun merilis pengumuman bahwa kegiatan perku
 
 Kami pun separuh senang dan separuh lagi kuatir. Karena, jika memang kondisi di luar seperti apa yang diberitakan, bukan tidak mungkin kami tidak akan bisa pulang ke rumah jika tetap memaksakan tinggal di Bandung.
 
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/writing/2023/first-experience-of-online-thesis-defense/VID-20200316-WA0015.gif" class="right" alt="video gif saat petugas peron stasiun memeriksa suhu penumpang" width="50%" caption="suhu dicek oleh petugas peron stasiun" >}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/writing/2023/first-experience-of-online-thesis-defense/VID-20200316-WA0015.gif" width="50%" alt="video gif saat petugas peron stasiun memeriksa suhu penumpang"><figcaption>suhu dicek oleh petugas peron stasiun</figcaption></figure>
 
 Dengan membawa barang bawaan secukupnya koper dari kos, kami pun segera menuju stasiun Kiaracondong yang ternyata sudah penuh dengan calon penumpang bermasker.
 
@@ -60,7 +60,7 @@ Setelah tubuh terasa kering karena harus mencari agen penjual yang memberikan ha
 
 _Alhamdulillah_ sidang akhir saya pun bisa terlaksana dengan baik pada 2 Juli 2020. Bahkan terasa dimudahkan oleh Allah SWT. Terutama Pak Doan selaku penguji yang tiba-tiba mengakhiri sidang karena beliau harus bersiap untuk menjadi imam di masjid haha. (Terima kasih bapak!)
 
-{{< figure src="IMG-20200702-WA0004.webp" alt="sidang tugas akhir secara daring" width="95%" caption="sidang tugas akhir kedua" >}}
+<figure><img src="IMG-20200702-WA0004.webp" width="95%" alt="sidang tugas akhir secara daring"><figcaption>sidang tugas akhir kedua</figcaption></figure>
 
 ## Pelajaran yang Dapat Diambil
 

--- a/src/writing/2023/set-up-first-but-not-first-vps/index.md
+++ b/src/writing/2023/set-up-first-but-not-first-vps/index.md
@@ -29,7 +29,7 @@ Hari-hari pun terbagi dengan urusan kerjaan, urusan hati&mdash;_ehem_ perut dan 
 
 VPS Hetzner itu pun akhirnya terbengkalai. Hingga sebuah _email_ aneh masuk. Isinya memberitahukan bahwa alamat tagian (_invoices_) saya sudah berganti. _Ja*cok_. Saya baru tahu rasanya kena retas.
 
-{{< figure src="hetzner-account-got-hacked.webp" width="90%" alt="info akun hetzner saya yang diretas melalui email" caption="ancaman kartu debit online hahaha" >}}
+<figure><img src="hetzner-account-got-hacked.webp" width="90%" alt="info akun hetzner saya yang diretas melalui email"><figcaption>ancaman kartu debit online hahaha</figcaption></figure>
 
 Beruntung tim _support_ sangat tanggap saat saya mengirim email untuk melaporkan insiden itu. Mereka akhirnya membalas: "_As your account got hacked and you had no products (except the ones ordered by the hacker) we have cancelled your account._"
 

--- a/src/writing/2023/the-end-of-wicked-a-rhyme/index.md
+++ b/src/writing/2023/the-end-of-wicked-a-rhyme/index.md
@@ -13,7 +13,7 @@ tags:
 ---
 
 <br/>
-{{< figure src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2019-04-20/IMG_20190420_173415.webp" width="75%" alt="foto masjid Al Irsyad Satya, Kota Baru Parahyangan">}}
+<figure><img src="https://cdn.statically.io/gh/fanajib5/blog/main/content/gallery/2019-04-20/IMG_20190420_173415.webp" width="75%" alt="foto masjid Al Irsyad Satya, Kota Baru Parahyangan"></figure>
 
 Man's becoming more corrupt now, godless, wicked, and cruel<br/>
 The soulless man stood silenced, their empty promises rang so true<br/>

--- a/src/writing/2023/thesis-defense-and-the-third-degrees-journey/index.md
+++ b/src/writing/2023/thesis-defense-and-the-third-degrees-journey/index.md
@@ -54,7 +54,7 @@ Hari-hari dengan beberapa sesi bimbingan denan beliau pun terlewat. Tepat sebelu
 
 Akhirnya, seminar proposal saya pun berhasil dilaksanakan dengan hasil revisi pada metode penelitian secara besar-besaran haha. Apa mau dikata, itulah hasil pengerjaan yang setengah hati (maaf ya, Prof!).
 
-{{< figure src="seminar-proposal-tesis.webp" alt="foto seminar proposal tesis Faiq" caption="Seminar proposal tesis" >}}
+<figure><img src="seminar-proposal-tesis.webp" alt="foto seminar proposal tesis Faiq"><figcaption>Seminar proposal tesis</figcaption></figure>
 
 ## Menjadi Seorang Deadliner (Lagi) yang Malas
 
@@ -110,7 +110,7 @@ Ditambah, saya kembali beruntung saat [Bu Mahe](https://www.its.ac.id/si/profil-
 
 Terlepas dari itu semua, saya bersyukur dapat melewati seminar akhir sidang tesis dengan baik. Terlebih setelah niat dan menata hati lagi dengan perlahan.
 
-{{< figure src="seminar-akhir-tesis.webp" alt="foto seminar akhir tesis Faiq" caption="seminar akhir tesis" >}}
+<figure><img src="seminar-akhir-tesis.webp" alt="foto seminar akhir tesis Faiq"><figcaption>seminar akhir tesis</figcaption></figure>
 
 ## Pelajaran yang Dapat Diambil
 


### PR DESCRIPTION
Converted all Hugo-style figure shortcodes ({{< figure >}}) to standard HTML <figure> tags to fix Nunjucks template parsing errors during build. This resolves the "expected variable end" error that was preventing the site from building successfully.

- Converted 11 markdown files with figure shortcodes to HTML
- Added figure shortcode handler to Eleventy config (for future use)
- Successfully tested build with all files rendering correctly