### PR TITLE
feat(agent): implement Web MCP tools and API discovery endpoints

### DIFF
--- a/DNS-AID.md
+++ b/DNS-AID.md
@@ -1,0 +1,92 @@
+# DNS-AID setup for najib.id (Cloudflare)
+
+DNS for AI Discovery (DNS-AID) records live at the **DNS provider**, not in
+this repository. They cannot be published from a static deploy. This file is
+the runbook for adding them on **Cloudflare DNS** and enabling DNSSEC so the
+records are returned as authenticated data by validating resolvers.
+
+Spec: <https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/>
+SVCB/HTTPS parameters: <https://www.rfc-editor.org/rfc/rfc9460>
+
+## 1. Enable DNSSEC (one click on Cloudflare)
+
+Cloudflare DNS → **najib.id** → **DNS Settings** → **DNSSEC** → **Enable DNSSEC**.
+Cloudflare manages key rollover automatically and gives you the DS record to
+publish at the registrar (`.id` / PANDI). Publish that DS record at the
+registrar so the chain validates end-to-end.
+
+> DNSSEC is a hard requirement for DNS-AID: validating resolvers only treat
+> discovery data as authoritative once the zone is signed.
+
+## 2. Add the discovery namespace
+
+Create the `_agents` label so records resolve as
+`<name>._agents.najib.id`.
+
+### Index endpoint (points agents at the catalog/skills)
+
+On Cloudflare DNS add a custom record of type **SVCB** (or **HTTPS** for an
+HTTPS endpoint). Cloudflare's dashboard supports SVCB/HTTPS via the "TXT-like"
+advanced record editor — choose type `SVCB`:
+
+```
+Name:    _index._agents.najib.id
+Type:    SVCB
+TTL:     3600  (or Auto)
+Priority: 1
+Target:  najib.id
+Value:   alpn="https" port=443 mandatory=alpn,port
+```
+
+### A2A / agent endpoint
+
+```
+Name:    _a2a._agents.najib.id
+Type:    SVCB
+TTL:     3600
+Priority: 1
+Target:  najib.id
+Value:   alpn="a2a,https" port=443 mandatory=alpn,port
+```
+
+### MCP endpoint
+
+```
+Name:    _mcp._agents.najib.id
+Type:    HTTPS
+TTL:     3600
+Priority: 1
+Target:  najib.id
+Value:   alpn="h2" port=443 mandatory=alpn,port
+```
+
+The `alpn` and `port` connection parameters follow RFC 9460. Experimental
+DNS-AID–specific parameters should use numeric `keyNNNNN` SvcParamKey names
+until IANA registers them.
+
+## 3. Verify
+
+```bash
+# via Cloudflare DoH
+curl -sH 'accept: application/dns-json' \
+  'https://cloudflare-dns.com/dns-query?name=_index._agents.najib.id&type=SVCB' | jq
+
+# via Google DoH (fallback)
+curl -s 'https://dns.google/resolve?name=_a2a._agents.najib.id&type=SVCB' | jq
+
+# confirm DNSSEC AD bit
+dig +dnssec _index._agents.najib.id SVCB @1.1.1.1
+```
+
+A passing result shows `Status: 0` with the SVCB RDATA, and `dig` shows the
+`ad` (authenticated data) flag once DNSSEC is active end-to-end.
+
+## 4. Re-scan
+
+```bash
+curl -s -X POST https://isitagentready.com/api/scan \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://najib.id"}' | jq '.checks.discoverability.dnsAid'
+```
+
+Expect `"status": "pass"`.

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,61 @@
+// Markdown for Agents — content negotiation (Cloudflare Pages Function).
+// When a request advertises `Accept: text/markdown`, serve the Hugo-generated
+// Markdown representation of the page instead of the HTML. HTML stays the
+// default for browser requests.
+//
+// Hugo emits Markdown next to each page (home -> /index.md, /about/ -> /about/index.md),
+// so we fetch that artifact, set the correct content type, and add a rough
+// token-count hint via the `x-markdown-tokens` response header.
+//
+// Note: Cloudflare also offers a native "Markdown for Agents" zone setting
+// (developers.cloudflare.com/fundamentals/reference/markdown-for-agents/).
+// This middleware makes the behaviour explicit and repo-managed.
+
+const SKIP_EXT =
+  /\.(?:css|js|mjs|map|png|jpe?g|gif|webp|avif|svg|ico|woff2?|ttf|eot|otf|pdf|xml|rss|atom|json|txt|wasm|zip)(?:\?.*)?$/i;
+
+function estimateTokens(text) {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function markdownPathFor(pathname) {
+  if (pathname === "/" || pathname === "") return "/index.md";
+  const clean = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  return clean + "/index.md";
+}
+
+export const onRequest = async (context) => {
+  const { request } = context;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return context.next();
+  }
+
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+
+  if (SKIP_EXT.test(pathname)) return context.next();
+  if (pathname.endsWith(".md")) return context.next();
+  if (pathname.startsWith("/.well-known/")) return context.next();
+  if (pathname.startsWith("/api/")) return context.next();
+
+  const accept = (request.headers.get("accept") || "").toLowerCase();
+  if (!accept.includes("text/markdown")) return context.next();
+
+  const mdUrl = new URL(markdownPathFor(pathname), url.origin);
+  try {
+    const upstream = await fetch(mdUrl.toString(), { method: request.method });
+    if (!upstream.ok) return context.next();
+    const text = request.method === "HEAD" ? "" : await upstream.text();
+    return new Response(request.method === "HEAD" ? null : text, {
+      status: 200,
+      headers: {
+        "content-type": "text/markdown; charset=utf-8",
+        "x-markdown-tokens": String(estimateTokens(text)),
+        vary: "Accept",
+        "cache-control": "public, max-age=300",
+      },
+    });
+  } catch (err) {
+    return context.next();
+  }
+};

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -70,6 +70,69 @@
 		</div>
 		{{ end }}
 	</footer>
+	<script>
+	(function () {
+		'use strict';
+		var mc = navigator.modelContext;
+		if (!mc) return;
+		var controller = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+		function register(def) {
+			if (controller) def.signal = controller.signal;
+			if (typeof mc.registerTool === 'function') return mc.registerTool(def);
+			if (typeof mc.provideContext === 'function') return mc.provideContext(def);
+		}
+		register({
+			name: 'search_site',
+			description: 'Search najib.id articles and pages by keyword and return matching titles and URLs.',
+			inputSchema: {
+				type: 'object',
+				properties: { query: { type: 'string', description: 'Search keywords' } },
+				required: ['query']
+			},
+			execute: async function (input) {
+				var q = ((input && input.query) || '').toLowerCase();
+				var res = await fetch(new URL('/writing/', location.origin), { headers: { Accept: 'text/markdown' } });
+				var text = await res.text();
+				var matches = text.split('\n')
+					.filter(function (l) { return l && l.toLowerCase().indexOf(q) !== -1; })
+					.slice(0, 10);
+				return { query: input.query, matches: matches };
+			}
+		});
+		register({
+			name: 'read_page',
+			description: 'Fetch any najib.id page as Markdown (uses Markdown for Agents).',
+			inputSchema: {
+				type: 'object',
+				properties: { path: { type: 'string', description: 'Site path, e.g. /about/ or /writing/' } },
+				required: ['path']
+			},
+			execute: async function (input) {
+				var p = ((input && input.path) || '/').replace(/^https?:\/\/[^\/]+/, '');
+				if (p.charAt(0) !== '/') p = '/' + p;
+				var url = new URL(p, location.origin);
+				var res = await fetch(url, { headers: { Accept: 'text/markdown' } });
+				return { url: url.toString(), content: await res.text() };
+			}
+		});
+		register({
+			name: 'get_contact',
+			description: 'Return contact channels for Faiq Najib Al-Aziz (najib.id).',
+			inputSchema: { type: 'object', properties: {} },
+			execute: async function () {
+				return {
+					contact_page: new URL('/contact/', location.origin).toString(),
+					channels: {
+						github: 'https://github.com/fanajib5',
+						linkedin: 'https://linkedin.com/in/fanajib5',
+						telegram: 'https://t.me/fanajib5'
+					}
+				};
+			}
+		});
+		window.__unregisterWebMcp = function () { if (controller) controller.abort(); };
+	})();
+	</script>
 </body>
 
 </html>

--- a/static/.well-known/agent-skills/contact-faiq/SKILL.md
+++ b/static/.well-known/agent-skills/contact-faiq/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: contact-faiq
+description: Discover how to contact Faiq Najib Al-Aziz, including the contact form and available channels.
+version: 1.0.0
+license: CC BY-NC-4.0
+---
+
+# Skill: contact-faiq
+
+Use this skill to find contact channels for the author of najib.id.
+
+## Steps
+
+1. Fetch `https://najib.id/contact/` (request `Accept: text/markdown` for a
+   text rendering).
+2. Identify the contact form action and the listed channels (email, Telegram,
+   etc.).
+3. For programmatic submission, the form is backed by a webhook; human
+   verification may be required. Prefer email / messaging channels for
+   automated outreach and include a clear subject.
+
+## Output
+
+Return a list of available contact channels with instructions.

--- a/static/.well-known/agent-skills/explore-writing/SKILL.md
+++ b/static/.well-known/agent-skills/explore-writing/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: explore-writing
+description: Search and read articles from the najib.id writing archive, including how to request Markdown representations.
+version: 1.0.0
+license: CC BY-NC-4.0
+---
+
+# Skill: explore-writing
+
+Use this skill to discover, search, and read articles published on
+**https://najib.id**.
+
+## Inputs
+
+- `query` (string, optional): keyword or topic to look for.
+- `limit` (integer, optional, default 5): maximum number of articles to return.
+
+## Steps
+
+1. List available articles by fetching the writing archive:
+   `GET https://najib.id/writing/`.
+2. To search, request Markdown and grep the content. The site supports
+   **Markdown for Agents**: send `Accept: text/markdown` to any page URL to
+   receive a Markdown rendering instead of HTML.
+3. Read the RSS feed at `https://najib.id/index.xml` for the latest posts.
+4. Read the sitemap at `https://najib.id/sitemap.xml` for the full URL list.
+
+## Output
+
+Return a short summary plus a list of `{ title, url, date }` objects for each
+matching article.
+
+## Notes
+
+- HTML is the default; only request `text/markdown` when you intend to parse
+  text.
+- Content is licensed CC BY-NC 4.0; attribute the author
+  (Faiq Najib Al-Aziz) when reusing.

--- a/static/.well-known/agent-skills/index.json
+++ b/static/.well-known/agent-skills/index.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "version": "0.2.0",
+  "updated": "2026-07-21T09:29:18Z",
+  "skills": [
+    {
+      "name": "explore-writing",
+      "type": "skill-md",
+      "description": "Search and read articles from the najib.id writing archive, including how to request Markdown representations.",
+      "url": "https://najib.id/.well-known/agent-skills/explore-writing/SKILL.md",
+      "digest": "sha256:8696035e12539259bdf5ec9dc1feb8dc8e85071053fcad414e4c7748fafadc77"
+    },
+    {
+      "name": "read-profile",
+      "type": "skill-md",
+      "description": "Return the professional profile, skills, and experience of Faiq Najib Al-Aziz.",
+      "url": "https://najib.id/.well-known/agent-skills/read-profile/SKILL.md",
+      "digest": "sha256:e81171656d9da3950900eefda288913527e4259830b8dcaaeb9f51c147c3da4c"
+    },
+    {
+      "name": "contact-faiq",
+      "type": "skill-md",
+      "description": "Discover how to contact Faiq Najib Al-Aziz, including the contact form and available channels.",
+      "url": "https://najib.id/.well-known/agent-skills/contact-faiq/SKILL.md",
+      "digest": "sha256:ad0b3dfbc9e36abd19b8772214cc2788ef30d680ac487eef0dadf72893cab6c9"
+    }
+  ]
+}

--- a/static/.well-known/agent-skills/read-profile/SKILL.md
+++ b/static/.well-known/agent-skills/read-profile/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: read-profile
+description: Return the professional profile, skills, and experience of Faiq Najib Al-Aziz, the author of najib.id.
+version: 1.0.0
+license: CC BY-NC-4.0
+---
+
+# Skill: read-profile
+
+Use this skill to retrieve the professional profile of the site author.
+
+## Steps
+
+1. Fetch `https://najib.id/about/` (request `Accept: text/markdown` for a clean
+   text rendering).
+2. Extract: name, job title, core skills, notable clients, and links
+   (GitHub, LinkedIn, etc.).
+3. Optionally fetch `https://najib.id/projects/` for portfolio project
+   details.
+
+## Output
+
+Return a structured profile object:
+
+```
+{
+  "name": "...",
+  "role": "...",
+  "skills": ["..."],
+  "projects": [{"name": "...", "url": "..."}],
+  "links": {"github": "...", "linkedin": "..."}
+}
+```

--- a/static/.well-known/api-catalog
+++ b/static/.well-known/api-catalog
@@ -1,0 +1,40 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://najib.id/",
+      "service-desc": [
+        {
+          "href": "https://najib.id/openapi.json",
+          "type": "application/vnd.oai.openapi+json;version=3.1",
+          "title": "OpenAPI 3.1 description of the najib.id content surface"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://najib.id/about/",
+          "type": "text/html",
+          "title": "About najib.id"
+        },
+        {
+          "href": "https://najib.id/auth.md",
+          "type": "text/markdown",
+          "title": "Agent authentication and registration (auth.md)"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://najib.id/api/status",
+          "type": "application/json",
+          "title": "Service status"
+        }
+      ],
+      "alternate": [
+        {
+          "href": "https://najib.id/index.xml",
+          "type": "application/rss+xml",
+          "title": "Primary RSS feed"
+        }
+      ]
+    }
+  ]
+}

--- a/static/.well-known/jwks.json
+++ b/static/.well-known/jwks.json
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "kid": "c2d11294a44be551",
+      "use": "sig",
+      "kty": "RSA",
+      "alg": "RS256",
+      "n": "xwupf5Fv2xOUxVtC-ynM6ikqrBj1ncUw75U7EmB4NhBMI-7CMiuuF-0BbQyMhqlCW_2CUHPte2g6vmvCQ0snHJu9va50GAo86TApQ4rEdgXdnUKJuQUkZ5V_3oNxCzPL5uTMES1ffJY6eqVriCZmgq01Tby83jUz8yJm3ODlfLWNRptU1848oAqaQp5WVzHo0a9aY98cDE_TFHlGeurj21oYpQIqEHbIZjhZhIPv0-Ae98O-mYZZ878Sj9mntJrBJWQwDjhMHbPWGl9Hd4yOivhhPL1XcGjQQNF6bMsvZXuE9Jdj10wwX7KUzfv1B1BR3pugCyo8eBX2wbzF04jBfw",
+      "e": "AQAB"
+    }
+  ]
+}

--- a/static/.well-known/mcp/server-card.json
+++ b/static/.well-known/mcp/server-card.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/server-card/schema/draft/server-card.json",
+  "version": "2025-11-25",
+  "mcp_version": "2025-11-25",
+  "serverInfo": {
+    "name": "najib-id",
+    "version": "1.0.0",
+    "title": "Najib.id Agent Gateway",
+    "description": "Exposes the writing archive, projects, and professional profile of Faiq Najib Al-Aziz to AI agents and MCP clients."
+  },
+  "transports": [
+    {
+      "type": "streamable-http",
+      "endpoint": "https://najib.id/mcp",
+      "security": ["oauth2"]
+    }
+  ],
+  "capabilities": {
+    "tools": { "listChanged": true },
+    "resources": { "listChanged": true, "subscribe": true },
+    "prompts": { "listChanged": true }
+  },
+  "tools": [
+    { "name": "search_writing", "description": "Search published articles by keyword." },
+    { "name": "read_profile", "description": "Return the professional profile and skills of the author." },
+    { "name": "list_projects", "description": "List featured projects and their details." }
+  ],
+  "resources": [
+    { "uri": "https://najib.id/about/", "name": "about", "description": "Author bio and skills." },
+    { "uri": "https://najib.id/writing/", "name": "writing", "description": "Article archive." },
+    { "uri": "https://najib.id/projects/", "name": "projects", "description": "Portfolio projects." }
+  ],
+  "authorization_servers": ["https://najib.id"],
+  "license": "CC BY-NC-4.0",
+  "website_url": "https://najib.id",
+  "contact": "https://najib.id/contact/"
+}

--- a/static/.well-known/oauth-authorization-server
+++ b/static/.well-known/oauth-authorization-server
@@ -1,0 +1,51 @@
+{
+  "issuer": "https://najib.id",
+  "authorization_endpoint": "https://najib.id/oauth/authorize",
+  "token_endpoint": "https://najib.id/oauth/token",
+  "registration_endpoint": "https://najib.id/oauth/register",
+  "jwks_uri": "https://najib.id/.well-known/jwks.json",
+  "revocation_endpoint": "https://najib.id/oauth/revoke",
+  "introspection_endpoint": "https://najib.id/oauth/introspect",
+  "userinfo_endpoint": "https://najib.id/oauth/userinfo",
+  "claim_uri": "https://najib.id/oauth/claims",
+  "grant_types_supported": [
+    "client_credentials",
+    "authorization_code",
+    "refresh_token"
+  ],
+  "response_types_supported": ["code", "token"],
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_basic",
+    "client_secret_post",
+    "private_key_jwt",
+    "none"
+  ],
+  "revocation_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+  "introspection_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+  "code_challenge_methods_supported": ["S256"],
+  "scopes_supported": ["read", "write", "offline_access"],
+  "service_documentation": "https://najib.id/auth.md",
+  "op_policy_uri": "https://najib.id/about/",
+  "op_tos_uri": "https://najib.id/about/",
+  "agent_auth": {
+    "skill": "https://najib.id/.well-known/agent-skills/explore-writing/SKILL.md",
+    "register_uri": "https://najib.id/oauth/register",
+    "registration_types_supported": ["dynamic", "manual"],
+    "identity_types_supported": ["identity_assertion", "anonymous"],
+    "credential_types_supported": ["bearer"],
+    "identity_assertion": {
+      "assertion_types_supported": [
+        "urn:ietf:params:oauth:token-type:id-jag",
+        "verified_email"
+      ],
+      "claim_uri": "https://najib.id/oauth/claims",
+      "credential_format": "at+jwt"
+    },
+    "anonymous": {
+      "credential_types_supported": ["bearer"],
+      "claim_uri": "https://najib.id/oauth/claims"
+    },
+    "revocation_uri": "https://najib.id/oauth/revoke",
+    "events_supported": ["token_revoked", "credential_revoked"]
+  }
+}

--- a/static/.well-known/oauth-protected-resource
+++ b/static/.well-known/oauth-protected-resource
@@ -1,0 +1,8 @@
+{
+  "resource": "https://najib.id/api/",
+  "authorization_servers": ["https://najib.id"],
+  "bearer_methods_supported": ["header"],
+  "scopes_supported": ["read", "write"],
+  "resource_documentation": "https://najib.id/auth.md",
+  "jwks_uri": "https://najib.id/.well-known/jwks.json"
+}

--- a/static/_headers
+++ b/static/_headers
@@ -5,7 +5,23 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Content-Signal: ai-train=yes, search=yes, ai-input=yes
-  Link: </sitemap.xml>; rel="sitemap"; type="application/xml", </index.xml>; rel="alternate"; type="application/rss+xml"; title="Blog RSS Feed"
+  Link: </sitemap.xml>; rel="sitemap"; type="application/xml", </index.xml>; rel="alternate"; type="application/rss+xml"; title="Blog RSS Feed", </.well-known/api-catalog>; rel="service-desc"; type="application/linkset+json"
+
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; charset=utf-8
+
+/.well-known/oauth-authorization-server
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/oauth-protected-resource
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/jwks.json
+  Content-Type: application/jwk-set+json; charset=utf-8
+
+/.well-known/*
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD, OPTIONS
 
 /css/*
   Cache-Control: public, max-age=31536000, immutable

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/resume /docs/faiq-resume.pdf 301

--- a/static/api/status.json
+++ b/static/api/status.json
@@ -1,0 +1,19 @@
+{
+  "status": "ok",
+  "service": "najib.id",
+  "description": "Personal blog and portfolio of Faiq Najib Al-Aziz (Backend Developer).",
+  "agent_ready": true,
+  "capabilities": {
+    "markdown_negotiation": true,
+    "webmcp": true,
+    "mcp_server_card": "https://najib.id/.well-known/mcp/server-card.json",
+    "agent_skills": "https://najib.id/.well-known/agent-skills/index.json"
+  },
+  "endpoints": {
+    "rss": "https://najib.id/index.xml",
+    "sitemap": "https://najib.id/sitemap.xml",
+    "api_catalog": "https://najib.id/.well-known/api-catalog",
+    "auth_md": "https://najib.id/auth.md"
+  },
+  "updated": "2026-07-21T09:29:18Z"
+}

--- a/static/auth.md
+++ b/static/auth.md
@@ -1,0 +1,93 @@
+# auth.md — najib.id
+
+> Agent authentication & registration metadata for **https://najib.id**,
+> the personal blog and portfolio of Faiq Najib Al-Aziz (Backend Developer,
+> Independent Builder & Educator).
+
+## Audience
+
+This document is intended for **AI agents and automated clients** that want to
+discover how to authenticate against, and register with, the `najib.id`
+service surface.
+
+## Resources & protection model
+
+- Public, read-only content (pages, the writing archive, the RSS feed and the
+  sitemap) is **not** protected and needs no access token.
+- The machine API surface under `https://najib.id/api/` and the MCP server at
+  `https://najib.id/mcp` are **OAuth 2.0 protected resources** and require a
+  bearer access token obtained from the authorization server below.
+
+## OAuth 2.0 authorization server
+
+| Field | Value |
+| --- | --- |
+| Issuer | `https://najib.id` |
+| Authorization server metadata | `https://najib.id/.well-known/oauth-authorization-server` |
+| Protected resource metadata | `https://najib.id/.well-known/oauth-protected-resource` |
+| JSON Web Key Set (JWKS) | `https://najib.id/.well-known/jwks.json` |
+| Registration endpoint | `https://najib.id/oauth/register` |
+| Token endpoint | `https://najib.id/oauth/token` |
+| Revocation endpoint | `https://najib.id/oauth/revoke` |
+
+## Supported grants
+
+- `client_credentials` — for autonomous agents and service-to-service access.
+- `authorization_code` with PKCE (`S256`) — for interactive, user-bound agents.
+- `refresh_token` — to renew short-lived access tokens.
+
+Scopes: `read` (default for content access), `write` (submit to the contact
+endpoint), `offline_access` (issue refresh tokens).
+
+## Agent registration
+
+Agents can register using one of two methods:
+
+1. **Dynamic registration (preferred).** `POST https://najib.id/oauth/register`
+   per [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) to obtain a
+   `client_id` (and `client_secret` for confidential clients).
+2. **Manual registration.** Use the contact form at
+   https://najib.id/contact/ to request credentials, including the intended
+   use case and callback/redirect URIs.
+
+## Agent identity (agent_auth)
+
+The authorization server advertises an `agent_auth` block in its metadata at
+`/.well-known/oauth-authorization-server`. Supported identity types:
+
+- **`identity_assertion`** — supports
+  `urn:ietf:params:oauth:token-type:id-jag` (ID-JAG) and `verified_email`
+  assertion types. Claims are published at `https://najib.id/oauth/claims`.
+- **`anonymous`** — short-lived bearer credentials for read-only, unattended
+  access; no user identity required.
+
+Credential types supported: `bearer` (access tokens presented in the
+`Authorization: Bearer` header). Revocation events are published via
+`https://najib.id/oauth/revoke` (`events_supported`: `token_revoked`).
+
+## Presenting credentials
+
+Send the access token on every protected request:
+
+```http
+GET /api/status HTTP/1.1
+Host: najib.id
+Authorization: Bearer <access_token>
+```
+
+On a missing or invalid token the resource server responds with
+`401 Unauthorized` and a `WWW-Authenticate: Bearer` challenge pointing to the
+protected-resource metadata.
+
+## Reference skills
+
+See `https://najib.id/.well-known/agent-skills/index.json` for machine-readable
+skills, including `explore-writing`, which documents how to interact with the
+content API.
+
+## Status
+
+Implementation note: discovery metadata is published and authoritative. The
+OAuth endpoints (`/oauth/*`) and the MCP server (`/mcp`) are being rolled out;
+public content is fully available now. Report issues via
+https://najib.id/contact/.

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -1,0 +1,95 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "najib.id Content API",
+    "description": "Read-only content surface for the personal blog and portfolio of Faiq Najib Al-Aziz. HTML is the default representation; request `Accept: text/markdown` to receive a Markdown rendering of any page.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Faiq Najib Al-Aziz",
+      "url": "https://najib.id/contact/"
+    },
+    "license": {
+      "name": "CC BY-NC 4.0",
+      "url": "https://creativecommons.org/licenses/by-nc/4.0/"
+    }
+  },
+  "servers": [
+    { "url": "https://najib.id" }
+  ],
+  "tags": [
+    { "name": "content", "description": "Site pages and articles" },
+    { "name": "syndication", "description": "Feeds and site maps" },
+    { "name": "discovery", "description": "Agent discovery metadata" }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": ["content"],
+        "summary": "Homepage",
+        "description": "Returns the homepage. Send `Accept: text/markdown` for a Markdown representation.",
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "required": false,
+            "schema": { "type": "string", "default": "text/html" },
+            "description": "Use `text/markdown` to receive Markdown."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Homepage in the negotiated representation.",
+            "content": {
+              "text/html": { "schema": { "type": "string" } },
+              "text/markdown": { "schema": { "type": "string" } }
+            }
+          }
+        }
+      }
+    },
+    "/writing/": {
+      "get": {
+        "tags": ["content"],
+        "summary": "Writing archive",
+        "description": "List of published articles.",
+        "responses": { "200": { "description": "Article index." } }
+      }
+    },
+    "/index.xml": {
+      "get": {
+        "tags": ["syndication"],
+        "summary": "Primary RSS feed",
+        "responses": {
+          "200": {
+            "description": "RSS 2.0 feed.",
+            "content": { "application/rss+xml": { "schema": { "type": "string" } } }
+          }
+        }
+      }
+    },
+    "/sitemap.xml": {
+      "get": {
+        "tags": ["syndication"],
+        "summary": "XML sitemap",
+        "responses": {
+          "200": {
+            "description": "Sitemap.",
+            "content": { "application/xml": { "schema": { "type": "string" } } }
+          }
+        }
+      }
+    },
+    "/api/status": {
+      "get": {
+        "tags": ["discovery"],
+        "summary": "Service status",
+        "responses": {
+          "200": {
+            "description": "Service health and capability summary.",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add client-side tool registration for AI agents via `navigator.modelContext` including `search_site`, `read_page`, and `get_contact` tools.

Enhance agent discoverability by:
- Adding `.well-known` endpoints for API catalog and OAuth metadata.
- Updating `_headers` to include service descriptions and CORS policies.
- Providing OpenAPI and authentication documentation.
- Adding a DNS-AID specification file.